### PR TITLE
.bashrc: fix the parent equality check for bash

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -3,7 +3,7 @@
 parent=$(ps -o comm= -p $PPID)
 
 # use zsh if available and configured
-if [ -x /bin/zsh ] && [ -f .zsh/override_bash ] && [ "x$parent" != "xzsh" ] && [ "x$parent" != "bash" ] ; then
+if [ -x /bin/zsh ] && [ -f .zsh/override_bash ] && [ "x$parent" != "xzsh" ] && [ "x$parent" != "xbash" ] ; then
     exec /bin/zsh
 fi
 


### PR DESCRIPTION
Just noticed this typo while browsing your dotfiles.